### PR TITLE
Add delays

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30309,7 +30309,7 @@ function processBranch(plan, branch, commitComments, params) {
             }
             const commentTag = "stale:" + branch.branchName;
             // Wait a bit to avoid rate limits
-            yield new Promise(r => setTimeout(r, 1500));
+            yield new Promise(r => setTimeout(r, 1000));
             return yield commitComments.addCommitComments({
                 commentTag,
                 commitSHA: branch.commitId,
@@ -30329,11 +30329,12 @@ function processBranch(plan, branch, commitComments, params) {
                 return;
             }
             // Wait a bit to avoid rate limits
-            yield new Promise(r => setTimeout(r, 2000));
+            yield new Promise(r => setTimeout(r, 1000));
             commitComments.deleteBranch(branch);
-            plan.comments.forEach((c) => {
+            plan.comments.forEach((c) => __awaiter(this, void 0, void 0, function* () {
+                yield new Promise(r => setTimeout(r, 1000));
                 commitComments.deleteCommitComments({ commentId: c.id });
-            });
+            }));
         }
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -15741,6 +15741,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -15826,7 +15834,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -30300,6 +30308,8 @@ function processBranch(plan, branch, commitComments, params) {
                 return;
             }
             const commentTag = "stale:" + branch.branchName;
+            // Wait a bit to avoid rate limits
+            yield new Promise(r => setTimeout(r, 1500));
             return yield commitComments.addCommitComments({
                 commentTag,
                 commitSHA: branch.commitId,
@@ -30318,6 +30328,8 @@ function processBranch(plan, branch, commitComments, params) {
                 console.log("-> (doing nothing because of dry run flag)");
                 return;
             }
+            // Wait a bit to avoid rate limits
+            yield new Promise(r => setTimeout(r, 2000));
             commitComments.deleteBranch(branch);
             plan.comments.forEach((c) => {
                 commitComments.deleteCommitComments({ commentId: c.id });
@@ -30603,6 +30615,14 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/src/removeStaleBranches.ts
+++ b/src/removeStaleBranches.ts
@@ -49,7 +49,7 @@ async function processBranch(
     const commentTag = "stale:" + branch.branchName;
 
     // Wait a bit to avoid rate limits
-    await new Promise(r => setTimeout(r, 1500));
+    await new Promise(r => setTimeout(r, 1000));
 
     return await commitComments.addCommitComments({
       commentTag,
@@ -83,11 +83,12 @@ async function processBranch(
     }
 
     // Wait a bit to avoid rate limits
-    await new Promise(r => setTimeout(r, 2000));
+    await new Promise(r => setTimeout(r, 1000));
 
     commitComments.deleteBranch(branch);
 
-    plan.comments.forEach((c) => {
+    plan.comments.forEach(async (c) => {
+      await new Promise(r => setTimeout(r, 1000));
       commitComments.deleteCommitComments({ commentId: c.id });
     });
   }

--- a/src/removeStaleBranches.ts
+++ b/src/removeStaleBranches.ts
@@ -47,6 +47,10 @@ async function processBranch(
     }
 
     const commentTag = "stale:" + branch.branchName;
+
+    // Wait a bit to avoid rate limits
+    await new Promise(r => setTimeout(r, 1500));
+
     return await commitComments.addCommitComments({
       commentTag,
       commitSHA: branch.commitId,
@@ -77,6 +81,9 @@ async function processBranch(
       console.log("-> (doing nothing because of dry run flag)");
       return;
     }
+
+    // Wait a bit to avoid rate limits
+    await new Promise(r => setTimeout(r, 2000));
 
     commitComments.deleteBranch(branch);
 


### PR DESCRIPTION
This just adds some delates to the mutate calls to try to avoid secondary rate limits.

There's a limit of 900 "points" of requests per minute, with read commands counting as 1 point, and write commands counting as 5 points.

The initial command bulk reads all the branches, but then each branch is processed individually. Adding a 1 second delay before any write commands should give us more than enough buffer here to get through all 500+ of our stale branches.

Once we're all caught up, we likely won't need this fork anymore since we'll most likely be dealing with single-digit numbers on a weekly basis, and even if we dip into the 20s or 30s, we'll still have plenty of headroom before we get anywhere near that 900 point limit.